### PR TITLE
Update  vnexte2e and vnextiat environment to fix pipeline issue for PBI 233696

### DIFF
--- a/src/UKHO.ADDS.Configuration.Domain/Schema/AddsEnvironment.cs
+++ b/src/UKHO.ADDS.Configuration.Domain/Schema/AddsEnvironment.cs
@@ -4,8 +4,8 @@
     {
         public static readonly AddsEnvironment Local = new("local");
         public static readonly AddsEnvironment Development = new("dev");
-        public static readonly AddsEnvironment VNextIat = new("vnext-iat");
-        public static readonly AddsEnvironment VNextE2E = new("vnext-e2e");
+        public static readonly AddsEnvironment VNextIat = new("vni");
+        public static readonly AddsEnvironment VNextE2E = new("vne");
         public static readonly AddsEnvironment Iat = new("iat");
         public static readonly AddsEnvironment PreProd = new("preprod");
         public static readonly AddsEnvironment Live = new("live");


### PR DESCRIPTION
This pull request updates environment identifiers in the `AddsEnvironment` class to use shorter, more concise names. 

### Changes to environment identifiers:

* [`src/UKHO.ADDS.Configuration.Domain/Schema/AddsEnvironment.cs`](diffhunk://#diff-ba28c10d55fc9de5093ff8003c8bbb051fd5f967333c2a314cbe35edc932192dL7-R8): Updated the `VNextIat` identifier from `"vnext-iat"` to `"vni"` and the `VNextE2E` identifier from `"vnext-e2e"` to `"vne"`.